### PR TITLE
Add a replay provider to test the app using replay files.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,118 +3,134 @@ import { AxiosResponse } from "axios";
 import cors from "cors";
 import http from "http";
 import { HubConnection } from "@microsoft/signalr";
-import WebSocketServer from "./websocketServer";
-import WebSocketClient from "./websocketClient";
+import { WebSocketTelemetryServer } from "./websocketServer";
+import { F1APIWebSocketsClient } from "./websocketClient";
+import { StateProcessor } from "./stateProcessor";
+import { ReplayProvider } from "./replayProvider";
 import router from "./api";
 import dotenv from "dotenv";
+import { EventEmitter } from "stream";
 dotenv.config()
 
-const app = express();
-const server = http.createServer(app);
-const PORT = 4000;
-
-const maxAttempts = 2;
-var attempts = 0;
-
-app.use(cors());
-
-app.use("/", router);
-
-const websocketClient = new WebSocketClient(); // Realiza la conexión al WebSocket F1 y es el event bus.
-
-const websocketServer = new WebSocketServer(server, websocketClient); // Maneja las conexiones de los clientes y escucha el event bus.
-
-server.listen(PORT, () => {
-  console.log("Server listening in port: " + PORT);
-});
-
 async function main() {
-  try {
-    const subscriptionToken = process.env.F1TVSUBSCRIPTION_TOKEN || "";
 
-    let negotiation: AxiosResponse;
-    let cookies: string[];
+  const app = express();
+  const server = http.createServer(app);
+  const PORT = 4000;
 
+  const maxAttempts = 2;
+  var attempts = 0;
+
+  app.use(cors());
+
+  app.use("/", router);
+
+  const stateProcessor = new StateProcessor(); // Procesa y mantiene el estado de la sesión actual.
+
+  let eventEmitter: EventEmitter;
+
+  if (process.env.REPLAY_FILE) {
+    const fastForwardSeconds = parseInt(process.env.REPLAY_FAST_FORWARD_SECONDS || "0");
+    const replayProvider = new ReplayProvider(process.env.REPLAY_FILE, stateProcessor, fastForwardSeconds); // Reproduce un archivo de replay y actualiza el stateProcessor.
+    eventEmitter = replayProvider;
+    replayProvider.run();
+  } else {
+    const websocketClient = new F1APIWebSocketsClient(stateProcessor); // Realiza la conexión al WebSocket F1 y es el event bus.
+    eventEmitter = websocketClient;
     try {
-      negotiation = await websocketClient.premiumNegotiation(subscriptionToken);
+      const subscriptionToken = process.env.F1TVSUBSCRIPTION_TOKEN || "";
 
-      let sock: HubConnection;
+      let negotiation: AxiosResponse;
+      let cookies: string[];
 
-      cookies = negotiation.headers["set-cookie"] ?? [];
+      try {
+        negotiation = await websocketClient.premiumNegotiation(subscriptionToken);
 
-      if (negotiation && negotiation.status === 200) {
-        if (negotiation.headers)
-          sock = await websocketClient.premiumWebsocketConnect(
-            subscriptionToken,
-            cookies
-          );
-        return;
+        let sock: HubConnection;
+
+        cookies = negotiation.headers["set-cookie"] ?? [];
+
+        if (negotiation && negotiation.status === 200) {
+          if (negotiation.headers)
+            sock = await websocketClient.premiumWebsocketConnect(
+              subscriptionToken,
+              cookies
+            );
+          return;
+        }
+      } catch (premiumError) {
+        console.warn("Premium connection failed: ", premiumError);
       }
-    } catch (premiumError) {
-      console.warn("Premium connection failed: ", premiumError);
-    }
 
-    try {
-      console.log("Started common negotiation.");
+      try {
+        console.log("Started common negotiation.");
 
-      const negotiationResponse = await websocketClient.commonNegotiation();
+        const negotiationResponse = await websocketClient.commonNegotiation();
 
-      const cookies: string[] = negotiationResponse.headers["set-cookie"] ?? [];
+        const cookies: string[] = negotiationResponse.headers["set-cookie"] ?? [];
 
-      const cookieString = cookies
-        .map((cookie) => cookie.split(";")[0].trim())
-        .join("; ");
+        const cookieString = cookies
+          .map((cookie) => cookie.split(";")[0].trim())
+          .join("; ");
 
-      const sock = await websocketClient.commonWebSocketConnection(
-        negotiationResponse.data["ConnectionToken"],
-        cookieString
-      );
+        const sock = await websocketClient.commonWebSocketConnection(
+          negotiationResponse.data["ConnectionToken"],
+          cookieString
+        );
 
-      sock.send(
-        JSON.stringify({
-          H: "Streaming",
-          M: "Subscribe",
-          A: [
-            [
-              "Heartbeat",
-              "CarData",
-              "Position",
-              "ExtrapolatedClock",
-              "TopThree",
-              "TimingStats",
-              "TimingAppData",
-              "WeatherData",
-              "TrackStatus",
-              "DriverList",
-              "RaceControlMessages",
-              "SessionInfo",
-              "SessionData",
-              "LapCount",
-              "TimingData",
-              "TyreStintSeries",
-              "TeamRadio",
-              "CarData.z",
-              "Position.z",
+        sock.send(
+          JSON.stringify({
+            H: "Streaming",
+            M: "Subscribe",
+            A: [
+              [
+                "Heartbeat",
+                "CarData",
+                "Position",
+                "ExtrapolatedClock",
+                "TopThree",
+                "TimingStats",
+                "TimingAppData",
+                "WeatherData",
+                "TrackStatus",
+                "DriverList",
+                "RaceControlMessages",
+                "SessionInfo",
+                "SessionData",
+                "LapCount",
+                "TimingData",
+                "TyreStintSeries",
+                "TeamRadio",
+                "CarData.z",
+                "Position.z",
+              ],
             ],
-          ],
-          I: 1,
-        })
-      );
-    } catch (commonError) {
-      console.error("Common connection failed:", commonError);
-    }
-  } catch (error) {
-    if (attempts < maxAttempts) {
-      console.log("Attempting to reconnect...");
-      const delay = Math.pow(2, attempts) * 1000
-      setTimeout(() => {
-        attempts++;
-        main();
-      }, delay);
-    } else {
-      console.log("Max reconnect attempts reached.", error);
+            I: 1,
+          })
+        );
+      } catch (commonError) {
+        console.error("Common connection failed:", commonError);
+      }
+    } catch (error) {
+      if (attempts < maxAttempts) {
+        console.log("Attempting to reconnect...");
+        const delay = Math.pow(2, attempts) * 1000
+        setTimeout(() => {
+          attempts++;
+          main();
+        }, delay);
+      } else {
+        console.log("Max reconnect attempts reached.", error);
+      }
     }
   }
+
+  new WebSocketTelemetryServer(server, stateProcessor, eventEmitter); // Maneja las conexiones de los clientes y escucha el event bus.
+
+  server.listen(PORT, () => {
+    console.log("Server listening in port: " + PORT);
+  });
+
 }
 
 main();

--- a/src/replayProvider.ts
+++ b/src/replayProvider.ts
@@ -39,14 +39,14 @@ export class ReplayProvider extends EventEmitter {
         initialStateJson.R.SessionInfo.GmtOffset = "00:00:00";
 
         // Initialize state with the first line
-        this.stateProcessor.updateState(lines.shift());
-        const firstMessageTimestamp = Date.parse(lines[0].M[0].A[2]);
+        this.stateProcessor.updateState(initialStateJson);
 
+        const firstMessageTimestamp = Date.parse(lines[1].M[0].A[2]);
         let lastProcessedTimestamp = firstMessageTimestamp;
 
         let firstQueuedMessageTimestamp: number | undefined = undefined;
 
-        for await (const line of lines) {
+        for await (const line of lines.slice(1)) {
             if (line.M) {
                 const messageTimestamp = Date.parse(line.M[0].A[2]);
                 if ((messageTimestamp - firstMessageTimestamp) < this.fastForwardSeconds * 1000) {

--- a/src/replayProvider.ts
+++ b/src/replayProvider.ts
@@ -1,0 +1,68 @@
+import * as fs from 'fs';
+import * as readlinePromises from 'readline/promises';
+
+import { StateProcessor } from './stateProcessor';
+import { EventEmitter } from 'stream';
+
+async function readReplayFile(filePath: string) {
+    const readLine = readlinePromises.createInterface({
+        input: fs.createReadStream(filePath),
+        crlfDelay: Infinity
+    });
+
+    const lines: any[] = []
+    for await (const line of readLine) {
+        lines.push(JSON.parse(line));
+    }
+    return lines;
+}
+
+export class ReplayProvider extends EventEmitter {
+    constructor(private filePath: string, private stateProcessor: StateProcessor, private fastForwardSeconds: number = 0) {
+        super();
+        this.setMaxListeners(0);
+    }
+
+    async run(): Promise<void> {
+        const lines = await readReplayFile(this.filePath);
+        const initialStateJson = lines[0]
+
+        const originalStartDate = new Date(initialStateJson.R.SessionInfo.StartDate);
+        const originalEndDate = new Date(initialStateJson.R.SessionInfo.EndDate);
+
+        const now = new Date();
+        const adjustedStartDate = new Date(now.getTime() - this.fastForwardSeconds * 1000);
+        const adjustedEndDate = new Date(adjustedStartDate.getTime() + (originalEndDate.getTime() - originalStartDate.getTime()));
+
+        initialStateJson.R.SessionInfo.StartDate = adjustedStartDate.toISOString();
+        initialStateJson.R.SessionInfo.EndDate = adjustedEndDate.toISOString();
+        initialStateJson.R.SessionInfo.GmtOffset = "00:00:00";
+
+        // Initialize state with the first line
+        this.stateProcessor.updateState(lines.shift());
+        const firstMessageTimestamp = Date.parse(lines[0].M[0].A[2]);
+
+        let lastProcessedTimestamp = firstMessageTimestamp;
+
+        let firstQueuedMessageTimestamp: number | undefined = undefined;
+
+        for await (const line of lines) {
+            if (line.M) {
+                const messageTimestamp = Date.parse(line.M[0].A[2]);
+                if ((messageTimestamp - firstMessageTimestamp) < this.fastForwardSeconds * 1000) {
+                    // Greedyly process messages until we reach the fast-forward threshold
+                    lastProcessedTimestamp = messageTimestamp;
+                    this.stateProcessor.processFeed(line.M[0].A[0], line.M[0].A[1], line.M[0].A[2]);
+                } else {
+                    if (!firstQueuedMessageTimestamp) {
+                        firstQueuedMessageTimestamp = lastProcessedTimestamp;
+                    }
+                    setTimeout(() => {
+                        this.stateProcessor.processFeed(line.M[0].A[0], line.M[0].A[1], line.M[0].A[2]);
+                        this.emit('broadcast', Buffer.from(JSON.stringify(line)));
+                    }, messageTimestamp - firstQueuedMessageTimestamp!);
+                }
+            }
+        }
+    }
+}

--- a/src/stateProcessor.ts
+++ b/src/stateProcessor.ts
@@ -3,7 +3,11 @@ interface FullState {
   R: any
 }
 
-class StateProcessor {
+interface StateProvider {
+  getState(): FullState;
+}
+
+class StateProcessor implements StateProvider {
   fullState: FullState;
 
   constructor() {
@@ -196,15 +200,4 @@ class StateProcessor {
   }
 }
 
-// Singleton pattern
-let instance: any = null;
-
-export = {
-  StateProcessor,
-  getInstance: () => {
-    if (!instance) {
-      instance = new StateProcessor();
-    }
-    return instance;
-  }
-};
+export { StateProcessor, StateProvider };

--- a/src/websocketClient.ts
+++ b/src/websocketClient.ts
@@ -1,15 +1,14 @@
 import EventEmitter from "events";
 import axios, { AxiosError } from "axios";
 import WebSocket from "ws";
-import stateProcessor from "./stateProcessor";
+import { StateProcessor } from "./stateProcessor";
 import { HttpTransportType, HubConnection, HubConnectionBuilder, LogLevel } from "@microsoft/signalr";
 
-class WebSocketClient extends EventEmitter {
+class F1APIWebSocketsClient extends EventEmitter {
     public state: any;
 
-    constructor() {
+    constructor(protected readonly stateProcessor: StateProcessor) {
         super()
-        this.state = stateProcessor.getInstance()
         this.setMaxListeners(0);
     }
 
@@ -55,7 +54,7 @@ class WebSocketClient extends EventEmitter {
                 // Guardar ultima información de retransmisión
                 const parsedData = JSON.parse(data.toString());
                 if (parsedData.R) {
-                    this.state.updateState(parsedData);
+                    this.stateProcessor.updateState(parsedData);
                     console.log("Basic data subscription fullfilled");
                 }
 
@@ -174,4 +173,4 @@ class WebSocketClient extends EventEmitter {
     }
 }
 
-export default WebSocketClient;
+export { F1APIWebSocketsClient };


### PR DESCRIPTION
This change cleans up some code and adds a replay feature to the WS API so data streams can be used to replicate the server behavior during a session. The feature also allows an optional `REPLAY_FAST_FORWARD_SECONDS` parameter to pre-process the first N seconds of the stream.

`
REPLAY_FILE=stream.json REPLAY_FAST_FORWARD_SECONDS =600 pnpm dev
`

Replay files consist of dumps where the first line is a full state in JSON, and subsequent lines can either be delta/partial updates or full states.

